### PR TITLE
feat(core-engine): add module for data source configuration

### DIFF
--- a/alembic/versions/0007_create_core_engine_tables.py
+++ b/alembic/versions/0007_create_core_engine_tables.py
@@ -1,0 +1,43 @@
+"""Crea las tablas del módulo Core Engine
+
+Revision ID: 0007
+Revises: 0006
+Create Date: 2024-07-18 18:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+import uuid
+
+
+# revision identifiers, used by Alembic.
+revision = '0007'
+down_revision = '0006'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ### DataSource Table ###
+    op.create_table('data_sources',
+    sa.Column('id', UUID(as_uuid=True), nullable=False, default=uuid.uuid4),
+    sa.Column('name', sa.String(length=100), nullable=False, comment='Nombre descriptivo, ej: \'PLC Línea de Ensamblaje 3\''),
+    sa.Column('protocol', sa.String(length=50), nullable=False, comment='Protocolo de comunicación, ej: \'OPCUA\', \'MODBUS_TCP\''),
+    sa.Column('connection_params', JSONB(), nullable=False, comment='Ej: {"host": "192.168.1.10", "port": 4840, "security_mode": "SignAndEncrypt"}'),
+    sa.Column('is_active', sa.Boolean(), nullable=False, default=False, comment='Habilita o deshabilita la recolección de datos de esta fuente.'),
+    sa.Column('description', sa.String(length=255), nullable=True),
+    sa.Column('created_at', sa.TIMESTAMP(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.Column('updated_at', sa.TIMESTAMP(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_data_sources_name'), 'data_sources', ['name'], unique=True)
+    op.create_index(op.f('ix_data_sources_protocol'), 'data_sources', ['protocol'], unique=False)
+    op.create_index(op.f('ix_data_sources_is_active'), 'data_sources', ['is_active'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_data_sources_is_active'), table_name='data_sources')
+    op.drop_index(op.f('ix_data_sources_protocol'), table_name='data_sources')
+    op.drop_index(op.f('ix_data_sources_name'), table_name='data_sources')
+    op.drop_table('data_sources')

--- a/app/api/v1/routers/__init__.py
+++ b/app/api/v1/routers/__init__.py
@@ -9,6 +9,8 @@ from app.identity import api as identity_api
 from app.assets import api as assets_api
 from app.telemetry import api as telemetry_api
 from app.procurement import api as procurement_api
+from app.maintenance import api as maintenance_api
+from app.core_engine import api as core_engine_api
 
 # --- Routers antiguos (se irán eliminando) ---
 from . import (
@@ -42,6 +44,8 @@ api_router.include_router(identity_api.router, prefix="/auth")
 api_router.include_router(assets_api.router) # El prefijo "/assets" ya está en el router
 api_router.include_router(telemetry_api.router) # El prefijo "/telemetry" ya está en el router
 api_router.include_router(procurement_api.router) # El prefijo "/procurement" ya está en el router
+api_router.include_router(maintenance_api.router) # El prefijo "/maintenance" ya está en el router
+api_router.include_router(core_engine_api.router) # El prefijo "/core-engine" ya está en el router
 
 
 # --- REGISTRO DE ROUTERS ANTIGUOS ---

--- a/app/core_engine/api.py
+++ b/app/core_engine/api.py
@@ -1,0 +1,49 @@
+# /app/core_engine/api.py
+"""
+API Router para el módulo Core Engine.
+
+Define los endpoints para gestionar las configuraciones de las fuentes de datos.
+"""
+
+import logging
+from typing import List
+import uuid
+
+from fastapi import APIRouter, Depends, status
+
+from app.core_engine import schemas
+from app.core_engine.service import CoreEngineService
+# --- MEJORA: Importamos el inyector de dependencias desde la ubicación central ---
+from app.dependencies.services import get_core_engine_service
+
+logger = logging.getLogger("app.core_engine.api")
+
+router = APIRouter(prefix="/core-engine", tags=["Core Engine"])
+
+
+@router.post(
+    "/data-sources",
+    summary="Crear una nueva fuente de datos",
+    status_code=status.HTTP_201_CREATED,
+    response_model=schemas.DataSourceRead,
+)
+def create_data_source(
+    data_source_in: schemas.DataSourceCreate,
+    core_engine_service: CoreEngineService = Depends(get_core_engine_service),
+):
+    """Registra una nueva fuente de datos (ej: un PLC) en el sistema."""
+    return core_engine_service.create_data_source(data_source_in)
+
+
+@router.get(
+    "/data-sources",
+    summary="Listar todas las fuentes de datos",
+    response_model=List[schemas.DataSourceRead],
+)
+def list_data_sources(
+    skip: int = 0,
+    limit: int = 100,
+    core_engine_service: CoreEngineService = Depends(get_core_engine_service),
+):
+    """Obtiene una lista paginada de todas las fuentes de datos configuradas."""
+    return core_engine_service.list_data_sources(skip=skip, limit=limit)

--- a/app/core_engine/models/__init__.py
+++ b/app/core_engine/models/__init__.py
@@ -1,0 +1,6 @@
+# /app/core_engine/models/__init__.py
+"""
+Expone los modelos del módulo Core Engine.
+"""
+
+from .data_source import DataSource

--- a/app/core_engine/models/data_source.py
+++ b/app/core_engine/models/data_source.py
@@ -1,0 +1,34 @@
+# /app/core_engine/models/data_source.py
+"""
+Modelo de la base de datos para la entidad DataSource.
+
+Representa la configuración de una fuente de datos externa, como un PLC,
+un gateway OPC UA o un broker MQTT.
+"""
+import uuid
+
+from sqlalchemy import Column, String, func, TIMESTAMP, Boolean
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+
+from app.db.base_class import Base
+
+
+class DataSource(Base):
+    """Modelo SQLAlchemy para una Fuente de Datos."""
+    __tablename__ = "data_sources"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+    name = Column(String(100), unique=True, index=True, nullable=False, comment="Nombre descriptivo, ej: 'PLC Línea de Ensamblaje 3'")
+    protocol = Column(String(50), nullable=False, index=True, comment="Protocolo de comunicación, ej: 'OPCUA', 'MODBUS_TCP'")
+    
+    # Campo JSON para almacenar parámetros de conexión flexibles.
+    # Ej: {"host": "192.168.1.10", "port": 4840, "security_mode": "SignAndEncrypt"}
+    connection_params = Column(JSONB, nullable=False)
+
+    is_active = Column(Boolean, default=False, nullable=False, index=True, comment="Habilita o deshabilita la recolección de datos de esta fuente.")
+    description = Column(String(255), nullable=True)
+
+    # --- Campos de Auditoría ---
+    created_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)

--- a/app/core_engine/repository.py
+++ b/app/core_engine/repository.py
@@ -1,0 +1,39 @@
+# /app/core_engine/repository.py
+"""
+Capa de Repositorio para el módulo Core Engine.
+
+Encapsula la lógica de acceso a datos para las entidades del módulo,
+comenzando por DataSource.
+"""
+
+from typing import List, Optional
+import uuid
+
+from sqlalchemy.orm import Session
+
+from app.core_engine import models, schemas
+
+
+class CoreEngineRepository:
+    """Realiza operaciones CRUD en la base de datos para el módulo Core Engine."""
+
+    def __init__(self, db: Session):
+        self.db = db
+
+    # --- Métodos para DataSource ---
+
+    def create_data_source(self, data_source_in: schemas.DataSourceCreate) -> models.DataSource:
+        """Crea una nueva fuente de datos en la base de datos."""
+        db_data_source = models.DataSource(**data_source_in.model_dump())
+        self.db.add(db_data_source)
+        self.db.commit()
+        self.db.refresh(db_data_source)
+        return db_data_source
+
+    def get_data_source(self, data_source_id: uuid.UUID) -> Optional[models.DataSource]:
+        """Obtiene una fuente de datos por su ID."""
+        return self.db.query(models.DataSource).filter(models.DataSource.id == data_source_id).first()
+
+    def list_data_sources(self, skip: int = 0, limit: int = 100) -> List[models.DataSource]:
+        """Lista todas las fuentes de datos con paginación."""
+        return self.db.query(models.DataSource).offset(skip).limit(limit).all()

--- a/app/core_engine/schemas.py
+++ b/app/core_engine/schemas.py
@@ -1,0 +1,32 @@
+# /app/core_engine/schemas.py
+"""
+Esquemas Pydantic para el módulo Core Engine.
+
+Define los contratos de datos para la API, empezando por la entidad DataSource.
+"""
+import uuid
+from datetime import datetime
+from typing import Optional, Any
+
+from pydantic import BaseModel, Field, Json
+
+
+# --- Esquemas para DataSource ---
+
+class DataSourceBase(BaseModel):
+    name: str = Field(..., example="PLC Línea de Ensamblaje 3")
+    protocol: str = Field(..., example="OPCUA")
+    connection_params: Json[Any] = Field(..., example='{"host": "192.168.1.10", "port": 4840}')
+    is_active: bool = Field(False, description="Habilita o deshabilita la recolección de datos.")
+    description: Optional[str] = Field(None, example="Controlador principal del brazo robótico de soldadura.")
+
+class DataSourceCreate(DataSourceBase):
+    pass
+
+class DataSourceRead(DataSourceBase):
+    id: uuid.UUID
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/app/core_engine/service.py
+++ b/app/core_engine/service.py
@@ -1,0 +1,35 @@
+# /app/core_engine/service.py
+"""
+Capa de Servicio para el módulo Core Engine.
+
+Contiene la lógica de negocio para gestionar las fuentes de datos y, en el futuro,
+la comunicación en tiempo real con el hardware de la planta.
+"""
+
+from typing import List, Optional
+import uuid
+from sqlalchemy.orm import Session
+
+from app.core_engine import models, schemas
+from app.core_engine.repository import CoreEngineRepository
+
+
+class CoreEngineService:
+    """Servicio de negocio para la gestión del motor de comunicación."""
+
+    def __init__(self, db: Session):
+        self.db = db
+        self.core_engine_repo = CoreEngineRepository(self.db)
+
+    def create_data_source(self, data_source_in: schemas.DataSourceCreate) -> models.DataSource:
+        """Crea una nueva configuración de fuente de datos."""
+        # Lógica futura: Validar que los connection_params son correctos para el protocolo.
+        return self.core_engine_repo.create_data_source(data_source_in)
+
+    def get_data_source(self, data_source_id: uuid.UUID) -> Optional[models.DataSource]:
+        """Obtiene una fuente de datos por su ID."""
+        return self.core_engine_repo.get_data_source(data_source_id)
+
+    def list_data_sources(self, skip: int = 0, limit: int = 100) -> List[models.DataSource]:
+        """Lista todas las fuentes de datos."""
+        return self.core_engine_repo.list_data_sources(skip, limit)

--- a/app/dependencies/services.py
+++ b/app/dependencies/services.py
@@ -10,6 +10,8 @@ from app.identity.auth_service import AuthService
 from app.assets.service import AssetService
 from app.telemetry.service import TelemetryService
 from app.procurement.service import ProcurementService
+from app.maintenance.service import MaintenanceService
+from app.core_engine.service import CoreEngineService
 
 # --- Dependencias antiguas (se irán eliminando a medida que refactoricemos) ---
 from app.contracts.IContactService import IContactService
@@ -45,20 +47,22 @@ from app.services.vital_sign_service import VitalSignService
 # --- Inyectores para Módulos de Astruxa ---
 
 def get_auth_service(db: Session = Depends(get_db)) -> AuthService:
-    """Proporciona una instancia del AuthService de Astruxa."""
     return AuthService(db)
 
 def get_asset_service(db: Session = Depends(get_db)) -> AssetService:
-    """Proporciona una instancia del AssetService de Astruxa."""
     return AssetService(db)
 
 def get_telemetry_service(db: Session = Depends(get_db)) -> TelemetryService:
-    """Proporciona una instancia del TelemetryService de Astruxa."""
     return TelemetryService(db)
 
 def get_procurement_service(db: Session = Depends(get_db)) -> ProcurementService:
-    """Proporciona una instancia del ProcurementService de Astruxa."""
     return ProcurementService(db)
+
+def get_maintenance_service(db: Session = Depends(get_db)) -> MaintenanceService:
+    return MaintenanceService(db)
+
+def get_core_engine_service(db: Session = Depends(get_db)) -> CoreEngineService:
+    return CoreEngineService(db)
 
 
 # --- Inyectores antiguos (se irán eliminando) ---


### PR DESCRIPTION
This commit introduces the `core_engine` module, which will be responsible for all real-time communication with plant hardware (PLCs, sensors, gateways).

This initial implementation establishes the foundational capability to configure and manage these data sources.

Key components include:
- A new `DataSource` model to store connection configurations for various industrial protocols (e.g., OPCUA, MODBUS_TCP). It uses a flexible JSONB field for `connection_params`.
- A self-contained, standard modular structure with its own API, service, repository, and schemas for creating and listing data sources.
- An Alembic migration to create the `data_sources` table in the database.

This module provides the necessary "address book" for the system to know which devices to connect to, paving the way for implementing the actual communication logic in future work.