### PR TITLE
feat(db): implement modular and comprehensive data seeding

### DIFF
--- a/app/db/seeding/_seed_assets.py
+++ b/app/db/seeding/_seed_assets.py
@@ -1,0 +1,78 @@
+# /app/db/seeding/_seed_assets.py
+"""
+Script de siembra para el módulo de Activos (AssetTypes, AssetHierarchy, Assets).
+"""
+
+import logging
+from sqlalchemy.orm import Session
+
+from app.assets.models import Asset, AssetType, AssetHierarchy
+from app.sectors.models import Sector
+
+logger = logging.getLogger(__name__)
+
+# --- Datos de Siembra Predefinidos ---
+
+ASSET_TYPES_DATA = {
+    # Machines & Robots
+    "Prensa Hidráulica Schuler 500T": {"category": "MACHINE"},
+    "Brazo Robótico KUKA KR 210": {"category": "ROBOT"},
+    # Sensors
+    "Cámara de Visión Cognex-1000": {"category": "SENSOR"},
+    "Sensor de Temperatura IFM-T2": {"category": "SENSOR"},
+    "Sensor de Presión Bosch-P1": {"category": "SENSOR"},
+    # PLCs & Components
+    "PLC Siemens S7-1500": {"category": "PLC"},
+    "Motor Eléctrico 150kW": {"category": "COMPONENT"},
+    "Bomba Hidráulica Rexroth": {"category": "COMPONENT"},
+}
+
+ASSET_HIERARCHY_DATA = [
+    {"parent": "Prensa Hidráulica Schuler 500T", "child": "PLC Siemens S7-1500", "quantity": 1},
+    {"parent": "Prensa Hidráulica Schuler 500T", "child": "Bomba Hidráulica Rexroth", "quantity": 2},
+    {"parent": "Brazo Robótico KUKA KR 210", "child": "PLC Siemens S7-1500", "quantity": 1},
+    {"parent": "Brazo Robótico KUKA KR 210", "child": "Motor Eléctrico 150kW", "quantity": 6},
+]
+
+ASSETS_DATA = [
+    # Línea 1
+    {"type": "Prensa Hidráulica Schuler 500T", "serial": "SCH-L1-001", "sector": "Línea de Estampado 1"},
+    {"type": "Brazo Robótico KUKA KR 210", "serial": "KUK-L1-001", "sector": "Línea de Estampado 1"},
+    {"type": "Cámara de Visión Cognex-1000", "serial": "COG-L1-001", "sector": "Línea de Estampado 1"},
+    # Línea 2
+    {"type": "Prensa Hidráulica Schuler 500T", "serial": "SCH-L2-001", "sector": "Línea de Estampado 2"},
+    {"type": "Brazo Robótico KUKA KR 210", "serial": "KUK-L2-001", "sector": "Línea de Estampado 2"},
+    {"type": "Cámara de Visión Cognex-1000", "serial": "COG-L2-001", "sector": "Línea de Estampado 2"},
+]
+
+def seed_assets(db: Session):
+    logger.info("Iniciando siembra de datos para Activos...")
+
+    # 1. Sembrar AssetTypes
+    for name, data in ASSET_TYPES_DATA.items():
+        if not db.query(AssetType).filter(AssetType.name == name).first():
+            db.add(AssetType(name=name, category=data["category"]))
+    db.commit()
+    logger.info("Tipos de Activos (AssetTypes) sembrados.")
+
+    # 2. Sembrar AssetHierarchy
+    for item in ASSET_HIERARCHY_DATA:
+        parent_type = db.query(AssetType).filter(AssetType.name == item["parent"]).one()
+        child_type = db.query(AssetType).filter(AssetType.name == item["child"]).one()
+        
+        existing_link = db.query(AssetHierarchy).filter_by(parent_asset_type_id=parent_type.id, child_asset_type_id=child_type.id).first()
+        if not existing_link:
+            db.add(AssetHierarchy(parent_asset_type_id=parent_type.id, child_asset_type_id=child_type.id, quantity=item["quantity"]))
+    db.commit()
+    logger.info("Jerarquía de Activos (AssetHierarchy) sembrada.")
+
+    # 3. Sembrar Assets
+    for item in ASSETS_DATA:
+        if not db.query(Asset).filter(Asset.serial_number == item["serial"]).first():
+            asset_type = db.query(AssetType).filter(AssetType.name == item["type"]).one()
+            sector = db.query(Sector).filter(Sector.name == item["sector"]).one()
+            db.add(Asset(asset_type_id=asset_type.id, serial_number=item["serial"], sector_id=sector.id, location=sector.name))
+    db.commit()
+    logger.info("Activos (Assets) sembrados.")
+
+    logger.info("Siembra de datos para Activos completada.")

--- a/app/db/seeding/_seed_core_engine.py
+++ b/app/db/seeding/_seed_core_engine.py
@@ -1,84 +1,62 @@
 # /app/db/seeding/_seed_core_engine.py
 """
-Siembra los datos de configuración inicial para el Core Engine, incluyendo
-una fuente de datos de prueba para el PLC simulado.
+Siembra la configuración de DataSource para conectar el PLC simulado
+a un activo existente en la base de datos.
 """
 
 import logging
- 
-import json
 from sqlalchemy.orm import Session
 
-from app.assets.models import Asset, AssetType
 from app.core_engine.models import DataSource
+from app.assets.models import Asset
 
 logger = logging.getLogger(__name__)
 
- 
 def seed_core_engine(db: Session):
     """
-    Crea una configuración de DataSource para el PLC simulado si no existe.
+    Crea una configuración de DataSource para el PLC simulado, vinculándola
+    a la prensa de la Línea 1 si no existe ya una DataSource para el simulador.
     """
     logger.info("Iniciando siembra de datos para el Core Engine...")
 
-    # 1. Crear un AssetType para el PLC simulado
-    simulated_plc_type = db.query(AssetType).filter(AssetType.name == "Simulated PLC").first()
-    if not simulated_plc_type:
-        logger.info("Creando AssetType 'Simulated PLC'...")
-        simulated_plc_type = AssetType(
-            name="Simulated PLC",
-            description="Un tipo de activo para el PLC de simulación de Astruxa.",
-            manufacturer="Astruxa Simulators",
-            category="PLC"
-        )
-        db.add(simulated_plc_type)
-        db.commit()
-        db.refresh(simulated_plc_type)
+    # No creamos nuevos activos, los buscamos de los que ya han sido sembrados.
+    press_line_1 = db.query(Asset).filter(Asset.serial_number == "SCH-L1-001").first()
 
-    # 2. Crear una instancia de Asset para el PLC simulado
-    simulated_asset = db.query(Asset).filter(Asset.serial_number == "SIM-PLC-001").first()
-    if not simulated_asset:
-        logger.info("Creando Asset 'SIM-PLC-001'...")
-        simulated_asset = Asset(
-            asset_type_id=simulated_plc_type.id,
-            serial_number="SIM-PLC-001",
-            location="Sala de Simulación",
-            status="operational"
-        )
-        db.add(simulated_asset)
-        db.commit()
-        db.refresh(simulated_asset)
+    if not press_line_1:
+        logger.error("No se pudo encontrar el activo 'Prensa Línea 1' (SCH-L1-001) para la siembra del Core Engine. Asegúrese de que el seeder de activos se haya ejecutado primero.")
+        return
 
-    # 3. Crear la DataSource para conectar con el PLC simulado
+    # Crear la DataSource para conectar con el PLC simulado
     data_source = db.query(DataSource).filter(DataSource.name == "PLC Simulator").first()
     if not data_source:
-        logger.info("Creando DataSource 'PLC Simulator'...")
+        logger.info("Creando DataSource 'PLC Simulator' y vinculándola a la Prensa de la Línea 1...")
+        
+        # Los datos de telemetría del simulador se asociarán a la prensa de la línea 1.
         connection_params = {
             "url": "opc.tcp://host.docker.internal:4840/astruxa/simulator/",
             "nodes": [
                 {
                     "node_id": "ns=2;s=PLC_1.Temperature",
                     "metric_name": "temperature_celsius",
-                    "asset_id": str(simulated_asset.id)
+                    "asset_id": str(press_line_1.id)
                 },
                 {
                     "node_id": "ns=2;s=PLC_1.Pressure",
                     "metric_name": "pressure_kpa",
-                    "asset_id": str(simulated_asset.id)
+                    "asset_id": str(press_line_1.id)
                 }
             ]
         }
- 
+        
         data_source = DataSource(
             name="PLC Simulator",
             protocol="OPCUA",
             connection_params=connection_params,
             is_active=True,
-            description="Fuente de datos para el servidor OPC UA de simulación."
+            description="Fuente de datos para el servidor OPC UA de simulación, monitoreando la Prensa de la Línea 1."
         )
         db.add(data_source)
         db.commit()
-        db.refresh(data_source)
         logger.info("DataSource 'PLC Simulator' creada y activada.")
     else:
         logger.warning("La DataSource 'PLC Simulator' ya existe. Saltando siembra.")

--- a/app/db/seeding/_seed_identity.py
+++ b/app/db/seeding/_seed_identity.py
@@ -1,0 +1,96 @@
+# /app/db/seeding/_seed_identity.py
+"""
+Script de siembra para el módulo de Identidad (Permissions, Roles, Users).
+"""
+
+import logging
+from sqlalchemy.orm import Session
+
+from app.identity.models import Permission, Role, User
+from app.sectors.models import Sector
+from app.core.security import hash_password
+
+logger = logging.getLogger(__name__)
+
+# --- Datos de Siembra Predefinidos ---
+
+PERMISSIONS_DATA = {
+    "admin:full-access": "Acceso total a todas las funcionalidades.",
+    "user:read": "Leer información de usuarios.",
+    "user:create": "Crear nuevos usuarios.",
+    "asset:read": "Leer información de activos.",
+    "asset:create": "Crear nuevos activos.",
+    "asset:update": "Actualizar información de activos.",
+    "workorder:read": "Leer órdenes de trabajo.",
+    "workorder:create": "Crear nuevas órdenes de trabajo.",
+    "workorder:assign": "Asignar órdenes de trabajo a técnicos o proveedores.",
+}
+
+ROLES_DATA = {
+    "Administrator": ["admin:full-access"],
+    "Supervisor": ["asset:read", "workorder:read", "workorder:create", "workorder:assign"],
+    "Technician": ["asset:read", "workorder:read"],
+    "Operator": ["asset:read"],
+}
+
+USERS_DATA = [
+    {
+        "email": "admin@astruxa.com",
+        "name": "Alice Admin",
+        "password": "admin_password",
+        "roles": ["Administrator"],
+        "sectors": ["Línea de Estampado 1", "Línea de Estampado 2", "Control de Calidad", "Área de Mantenimiento"]
+    },
+    {
+        "email": "supervisor@astruxa.com",
+        "name": "Bob Supervisor",
+        "password": "supervisor_password",
+        "roles": ["Supervisor"],
+        "sectors": ["Línea de Estampado 1", "Línea de Estampado 2"]
+    },
+    {
+        "email": "tech@astruxa.com",
+        "name": "Charlie Technician",
+        "password": "tech_password",
+        "roles": ["Technician"],
+        "sectors": ["Área de Mantenimiento"]
+    }
+]
+
+def seed_identity(db: Session):
+    logger.info("Iniciando siembra de datos para Identidad...")
+
+    # 1. Sembrar Permisos
+    for name, desc in PERMISSIONS_DATA.items():
+        if not db.query(Permission).filter(Permission.name == name).first():
+            db.add(Permission(name=name, description=desc))
+    db.commit()
+    logger.info("Permisos sembrados.")
+
+    # 2. Sembrar Roles y asignar Permisos
+    for name, perm_names in ROLES_DATA.items():
+        if not db.query(Role).filter(Role.name == name).first():
+            permissions = db.query(Permission).filter(Permission.name.in_(perm_names)).all()
+            db_role = Role(name=name, permissions=permissions)
+            db.add(db_role)
+    db.commit()
+    logger.info("Roles y asignación de permisos sembrados.")
+
+    # 3. Sembrar Usuarios y asignar Roles/Sectores
+    for user_data in USERS_DATA:
+        if not db.query(User).filter(User.email == user_data["email"]).first():
+            roles = db.query(Role).filter(Role.name.in_(user_data["roles"])).all()
+            sectors = db.query(Sector).filter(Sector.name.in_(user_data["sectors"])).all()
+            
+            db_user = User(
+                email=user_data["email"],
+                name=user_data["name"],
+                hashed_password=hash_password(user_data["password"]),
+                roles=roles,
+                assigned_sectors=sectors
+            )
+            db.add(db_user)
+    db.commit()
+    logger.info("Usuarios y asignación de roles/sectores sembrados.")
+
+    logger.info("Siembra de datos para Identidad completada.")

--- a/app/db/seeding/_seed_sectors.py
+++ b/app/db/seeding/_seed_sectors.py
@@ -1,0 +1,39 @@
+# /app/db/seeding/_seed_sectors.py
+"""
+Script de siembra para el módulo de Sectores.
+
+Pobla la base de datos con sectores de ejemplo para la planta imaginaria.
+"""
+
+import logging
+from sqlalchemy.orm import Session
+
+from app.sectors.models import Sector
+
+logger = logging.getLogger(__name__)
+
+def seed_sectors(db: Session):
+    """
+    Crea sectores de ejemplo si no existen.
+    """
+    logger.info("Iniciando siembra de datos para Sectores...")
+
+    sectors_data = [
+        {"name": "Línea de Estampado 1", "description": "Primera línea de producción de piezas de carrocería."},
+        {"name": "Línea de Estampado 2", "description": "Segunda línea de producción idéntica a la primera."},
+        {"name": "Almacén de Bobinas", "description": "Área de almacenamiento de materia prima (acero)."},
+        {"name": "Área de Mantenimiento", "description": "Zona dedicada a la reparación y mantenimiento de equipos."},
+        {"name": "Control de Calidad", "description": "Estación de inspección de piezas estampadas."},
+    ]
+
+    for sector_data in sectors_data:
+        existing_sector = db.query(Sector).filter(Sector.name == sector_data["name"]).first()
+        if not existing_sector:
+            db_sector = Sector(**sector_data)
+            db.add(db_sector)
+            logger.info(f"Sector creado: {sector_data["name"]}")
+        else:
+            logger.debug(f"Sector ya existe: {sector_data["name"]}. Saltando.")
+    
+    db.commit()
+    logger.info("Siembra de datos para Sectores completada.")

--- a/app/db/seeding/seed_all.py
+++ b/app/db/seeding/seed_all.py
@@ -10,13 +10,11 @@ import logging
 from sqlalchemy.orm import Session
 
 from app.core.database import SessionLocal
-
-# --- MEJORA: Usar importación absoluta para evitar errores de resolución ---
+# --- Importar todos los nuevos seeders de nuestros módulos ---
+from app.db.seeding._seed_sectors import seed_sectors
+from app.db.seeding._seed_identity import seed_identity
+from app.db.seeding._seed_assets import seed_assets
 from app.db.seeding._seed_core_engine import seed_core_engine
-
-# from ._seed_identity import seed_identity # Futuro
-# from ._seed_assets import seed_assets # Futuro
-
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -28,12 +26,11 @@ def seed_all(db: Session):
     """
     logger.info("--- Iniciando Proceso de Siembra Maestro para Astruxa ---")
     
-
-    # El orden es importante si hay dependencias entre los datos.
-    # seed_identity(db) # Ej: Crear Roles
-    # seed_assets(db)   # Ej: Crear AssetTypes
-    seed_core_engine(db) # Crear la DataSource para el simulador
-
+    # El orden es crucial para respetar las claves foráneas.
+    seed_sectors(db)
+    seed_identity(db)
+    seed_assets(db)
+    seed_core_engine(db)
     
     logger.info("--- Proceso de Siembra Maestro Finalizado ---")
 
@@ -43,9 +40,7 @@ if __name__ == "__main__":
     db_session = SessionLocal()
     try:
         seed_all(db_session)
-
-        db_session.commit()
-
+        # El commit final se hace dentro de cada seeder individualmente.
         logger.info("Siembra maestra completada con éxito.")
     except Exception as e:
         logger.error(f"Ocurrió un error inesperado durante la siembra maestra: {e}", exc_info=True)


### PR DESCRIPTION
This commit replaces the old, fragmented seeding scripts with a new, modular, and orchestrated data seeding strategy. This provides a rich, consistent, and realistic dataset for development and testing, modeling an entire imaginary plant.

Key changes include:
- Created a `_seed_sectors .py` script to populate plant areas.
- Created a `_seed_identity.py` script to populate Permissions, Roles, and Users with their corresponding relationships.
- Created a `_seed_assets.py` script to populate AssetTypes, AssetHierarchy (BOM), and physical Asset instances within sectors.
- Refactored `_seed_core_engine .py` to use existing assets from the new seed data, instead of creating its own.
- Updated the main `seed_all.py` script to act as an orchestrator, calling the modular seeders in the correct dependency order.